### PR TITLE
feat: show 'want to try' buttons even when user not logged in

### DIFF
--- a/database/postgresql/final/02-insert-data.sql
+++ b/database/postgresql/final/02-insert-data.sql
@@ -1155,7 +1155,6 @@ VALUES (
 );
 
 INSERT INTO "producers" (
-    "id", 
     "producerName", 
     "producerDesc", 
     "originCountry", 
@@ -1169,7 +1168,6 @@ INSERT INTO "producers" (
     "producerLink", 
     "stripeCustomerId"
 ) VALUES (
-    1, 
     'Hennessy', 
     'This is Hennessy', 
     'France', 
@@ -1185,7 +1183,6 @@ INSERT INTO "producers" (
 );
 
 INSERT INTO "venues" (
-    "id", 
     "venueName", 
     "address", 
     "venueType", 
@@ -1201,7 +1198,6 @@ INSERT INTO "venues" (
     "stripeCustomerId", 
     "pin"
 ) VALUES (
-    1, 
     'Orh Gao Taproom', 
     'Singapore', 
     'Bar', 
@@ -1219,33 +1215,33 @@ INSERT INTO "venues" (
 );
 
 INSERT INTO "producersQuestionAnswers" (
-	"id", "question", "answer", "date", "userId", "producerId")
-    VALUES (1, 'When are you going to release the next promotion?', 'SOON! CHECK FOR UPDATES!', '2024-10-04 16:08:59.899', 1, 1);
+    "question", "answer", "date", "userId", "producerId")
+    VALUES ('When are you going to release the next promotion?', 'SOON! CHECK FOR UPDATES!', '2024-10-04 16:08:59.899', 1, 1);
 
 INSERT INTO "listings" (
-	"id", "listingName", "producerID", "bottler", "originCountry", "drinkType", "abv", "officialDesc", "allowMod", "addedDate", "typeCategory", "age", "reviewLink", "sourceLink", "photo")
-	VALUES (1, 'Hennessy VS', 1, 'OB', 'Japan', 'Whiskey', 12, 'BEST EVEERRRR', true, '2024-10-05 00:14:37.661786', 'Spirit', 12, '', '', '');
+    "listingName", "producerID", "bottler", "originCountry", "drinkType", "abv", "officialDesc", "allowMod", "addedDate", "typeCategory", "age", "reviewLink", "sourceLink", "photo")
+	VALUES ('Hennessy VS', 1, 'OB', 'Japan', 'Whiskey', 12, 'BEST EVEERRRR', true, '2024-10-05 00:14:37.661786', 'Spirit', 12, '', '', '');
 
 INSERT INTO "usersFollowLists" (
-    "id", "userId", "users", "producers", "venues")
-    VALUES (1, 1, '{}', '{}', '{}'), (2, 2, '{}', '{}', '{}'), (3, 3, '{}', '{}', '{}'), (4, 4, '{}', '{}', '{}');
+    "userId", "users", "producers", "venues")
+    VALUES (1, '{}', '{}', '{}'), (2, '{}', '{}', '{}'), (3, '{}', '{}', '{}'), (4, '{}', '{}', '{}');
 
 INSERT INTO "usersDrinkLists" (
-    "id", "userId", "listName", "drinks")
+    "userId", "listName", "drinks")
     VALUES 
-    (1, 1, 'Drinks I Have Tried', '{}'), 
-    (2, 1, 'Drinks I Want To Try', '{}'), 
-    (3, 2, 'Drinks I Have Tried', '{}'), 
-    (4, 2, 'Drinks I Want To Try', '{}'), 
-    (5, 3, 'Drinks I Have Tried', '{}'), 
-    (6, 3, 'Drinks I Want To Try', '{}'), 
-    (7, 4, 'Drinks I Have Tried', '{}'), 
-    (8, 4, 'Drinks I Want To Try', '{}');
+    (1, 'Drinks I Have Tried', '{}'), 
+    (1, 'Drinks I Want To Try', '{}'), 
+    (2, 'Drinks I Have Tried', '{}'), 
+    (2, 'Drinks I Want To Try', '{}'), 
+    (3, 'Drinks I Have Tried', '{}'), 
+    (3, 'Drinks I Want To Try', '{}'), 
+    (4, 'Drinks I Have Tried', '{}'), 
+    (4, 'Drinks I Want To Try', '{}');
 
 INSERT INTO "venuesMenu" (
-    "id","sectionName", "sectionOrder","venueId")
-    VALUES(1, 'Created1', '0', 1);
+    "sectionName", "sectionOrder","venueId")
+    VALUES('Created1', '0', 1);
     
 INSERT INTO "menuItems"(
-    "id", "itemOrder", "itemPrice", "itemAvailability", "itemID", "itemServingType", "sectionId")
-VALUES(1, 0, 12.00, true, 1, 1, 1)
+    "itemOrder", "itemPrice", "itemAvailability", "itemID", "itemServingType", "sectionId")
+VALUES(0, 12.00, true, 1, 1, 1)

--- a/frontend/src/components/BookmarkIcon.vue
+++ b/frontend/src/components/BookmarkIcon.vue
@@ -9,14 +9,25 @@ handleIconClick(data) {
  -->
 
 <template>
-    <svg v-if="checkBookmarkStatus(listing.id)" xmlns="http://www.w3.org/2000/svg" :width="size" :height="size" fill="currentColor" class="bi bi-bookmark-fill" :class="{ 'overlay-icon': overlay }" viewBox="0 0 16 16"
-        data-bs-toggle="modal" data-bs-target="#bookmarkModal" @click="iconClicked">
-        <path d="M2 2v13.5a.5.5 0 0 0 .74.439L8 13.069l5.26 2.87A.5.5 0 0 0 14 15.5V2a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2"/>
-    </svg>
-    <svg v-else xmlns="http://www.w3.org/2000/svg" :width="size" :height="size" fill="currentColor" class="bi bi-bookmark" :class="{ 'overlay-icon': overlay }" viewBox="0 0 16 16"
-        data-bs-toggle="modal" data-bs-target="#bookmarkModal" @click="iconClicked">
-        <path d="M2 2a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v13.5a.5.5 0 0 1-.777.416L8 13.101l-5.223 2.815A.5.5 0 0 1 2 15.5zm2-1a1 1 0 0 0-1 1v12.566l4.723-2.482a.5.5 0 0 1 .554 0L13 14.566V2a1 1 0 0 0-1-1z"/>
-    </svg>
+    <!-- CP edits: added v-if div to ensure when public user click on bookmark icon, it does not throw out an error-->
+    <div v-if="user">
+        <svg v-if="checkBookmarkStatus(listing.id)" xmlns="http://www.w3.org/2000/svg" :width="size" :height="size" fill="currentColor" class="bi bi-bookmark-fill" :class="{ 'overlay-icon': overlay }" viewBox="0 0 16 16"
+            data-bs-toggle="modal" data-bs-target="#bookmarkModal" @click="iconClicked">
+            <path d="M2 2v13.5a.5.5 0 0 0 .74.439L8 13.069l5.26 2.87A.5.5 0 0 0 14 15.5V2a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2"/>
+        </svg>
+        <svg v-else xmlns="http://www.w3.org/2000/svg" :width="size" :height="size" fill="currentColor" class="bi bi-bookmark" :class="{ 'overlay-icon': overlay }" viewBox="0 0 16 16"
+            data-bs-toggle="modal" data-bs-target="#bookmarkModal" @click="iconClicked">
+            <path d="M2 2a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v13.5a.5.5 0 0 1-.777.416L8 13.101l-5.223 2.815A.5.5 0 0 1 2 15.5zm2-1a1 1 0 0 0-1 1v12.566l4.723-2.482a.5.5 0 0 1 .554 0L13 14.566V2a1 1 0 0 0-1-1z"/>
+        </svg>
+    </div>
+
+    <div v-else>
+        <svg xmlns="http://www.w3.org/2000/svg" :width="size" :height="size" fill="currentColor" class="bi bi-bookmark" :class="{ 'overlay-icon': overlay }" viewBox="0 0 16 16"
+            @click="iconClicked">
+            <path d="M2 2a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v13.5a.5.5 0 0 1-.777.416L8 13.101l-5.223 2.815A.5.5 0 0 1 2 15.5zm2-1a1 1 0 0 0-1 1v12.566l4.723-2.482a.5.5 0 0 1 .554 0L13 14.566V2a1 1 0 0 0-1-1z"/>
+        </svg>
+    </div>
+    
 </template>
 
 <script>
@@ -51,9 +62,17 @@ handleIconClick(data) {
                     }
                 }
             },
-            iconClicked() {
-                this.$emit('icon-clicked', this.listing.id);
-            }
+            iconClicked() {           
+                if (this.user) {
+                    this.$emit('icon-clicked', this.listing.id);
+                }
+                else {
+                    this.$emit('icon-clicked', 'login');
+                }
+                
+            },
+
+            
 
         }
     }

--- a/frontend/src/views/Producers/BottleListings.vue
+++ b/frontend/src/views/Producers/BottleListings.vue
@@ -386,21 +386,26 @@
                     
                     <!-- have tried button -->
                     <div class="col-2 col-lg-2 p-0">
-                        <div v-if="user && Object.keys(user.drinkLists).length > 0" v-html="checkDrinkLists(specified_listing).buttons.haveTried" class="d-grid" @click="addToTriedList"> </div>
+                        <!-- <div v-if="user && Object.keys(user.drinkLists).length > 0" v-html="checkDrinkLists(specified_listing).buttons.haveTried" class="d-grid" @click="addToTriedList"> </div> -->
+                        <!-- CP edits: Removed the if logic so public users can also view and click -->
+                        <div v-html="checkDrinkLists(specified_listing).buttons.haveTried" class="d-grid" @click="addToTriedList"> </div>
                     </div>
                     <!-- want to try button -->
                     <div class="col-2 col-lg-2 p-0">
-                        <div v-if="user && Object.keys(user.drinkLists).length > 0" v-html="checkDrinkLists(specified_listing).buttons.wantToTry" class="d-grid" @click="addToWantList"> </div>
+                        <!-- <div v-if="user && Object.keys(user.drinkLists).length > 0" v-html="checkDrinkLists(specified_listing).buttons.wantToTry" class="d-grid" @click="addToWantList"> </div> -->
+                        <!-- CP edits: Removed the if logic so public users can also view and click -->
+                        <div v-html="checkDrinkLists(specified_listing).buttons.wantToTry" class="d-grid" @click="addToWantList"> </div>
                     </div>
                     <!-- bookmark button -->
                     <div class="col-1 col-lg-1 text-center d-flex justify-content-start make-bookmark-bigger" >
+                        <!-- CP edits: removed v-if logic for public users to view and click -->
                         <BookmarkIcon 
-                            v-if="user" 
                             :user="user" 
                             :listing="specified_listing" 
                             :overlay="false"
                             size="30"
                             @icon-clicked="handleIconClick" />
+
                     </div>
                     
                 </div>
@@ -531,7 +536,7 @@
                         </div>
 
                     </div>
-                    <div v-else-if="userType == 'user'" class="col-5 mobile-view-hide">
+                    <div v-if="userID == 'defaultUser'" class="col-5 mobile-view-hide">
                         <div class="d-grid gap-2">
                             <router-link :to="{ path: '/login' }" class="reverse-clickable-text">
                                 <button class="btn primary-btn-less-round btn-lg"> 
@@ -775,7 +780,7 @@
                                     <!-- row 7: colours -->
                                     <div class="row">
                                         <div class="col-6 col-md-12 justify-content-start">
-                                            <p class = 'text-start mb-2 fw-bold'>Colour <span class="text-danger">*</span></p>
+                                            <p class = 'text-start mb-2 fw-bold'>Colour</p>
                                         </div>
                                     </div>
 
@@ -828,15 +833,15 @@
                                     <div class="row pt-2">
                                         <div class = 'col justify-content-start mb-3'>
                                             <div class="form-group mb-3">
-                                                <p class='text-start mb-2 fw-bold'>Aroma<span class="text-danger">*</span></p>
+                                                <p class='text-start mb-2 fw-bold'>Aroma</p>
                                                 <input v-model="aroma" type="text" class="form-control" id="aroma">
                                             </div>
                                             <div class="form-group mb-3">
-                                                <p class='text-start mb-2 fw-bold'>Taste<span class="text-danger">*</span></p>
+                                                <p class='text-start mb-2 fw-bold'>Taste</p>
                                                 <input v-model="taste" type="text" class="form-control" id="taste">
                                             </div>
                                             <div class="form-group mb-2">
-                                                <p class='text-start mb-2 fw-bold'>Finish<span class="text-danger">*</span></p>
+                                                <p class='text-start mb-2 fw-bold'>Finish</p>
                                                 <input v-model="finish" type="text" class="form-control" id="finish">
                                             </div>
                                         </div>
@@ -2697,6 +2702,12 @@
             },
             async addToTriedList(){
                 
+                // CP edits: Check if user is logged in
+                if (this.userID == "defaultUser") {
+                    // Redirect to login page
+                    this.$router.push('/login');
+                    return;
+                }
                 
                 let responseCode = "";
                 
@@ -2723,6 +2734,14 @@
                 }
             },
             async addToWantList(){
+
+                // CP edits: Check if user is logged in
+                if (this.userID == "defaultUser") {
+                    // Redirect to login page
+                    this.$router.push('/login');
+                    return;
+                }
+
                 let responseCode = "";
                 
                 let submitData = {
@@ -2836,7 +2855,12 @@
             },
             // for bookmark component
             handleIconClick(data) {
-                this.bookmarkListingID = data
+                if (data == 'login') {
+                    this.$router.push('/login');
+                }
+                else {
+                    this.bookmarkListingID = data
+                }
             },
 
             // Get current location using browser's Geolocation API

--- a/frontend/src/views/Users/BottleListings.vue
+++ b/frontend/src/views/Users/BottleListings.vue
@@ -139,6 +139,7 @@
                                     <div style="height: 85%;">
                                         <div v-if="questionsUpdates.length > 0" class="overflow-auto" style="max-height: 100%;">
                                             <div v-for="(update, index) in questionsUpdates" :key="index">
+                                                <!--Show if it's either producer or venue update-->
                                                 <span v-if="update.type == 'producerUpdate' || update.type == 'venueUpdate'">
                                                         <router-link v-if="update.type == 'producerUpdate'" :to="{ path: '/profile/producer/' + update.id }" class="reverse-text">
                                                             <img :src="(update.photo || defaultProfilePhoto)" style="width: 35px; height: 35px;" class="img-border">
@@ -154,6 +155,8 @@
                                                     <i>{{ getTimeDifference(update.date) }}</i>
                                                     <br><br>
                                                 </span>
+
+                                                <!-- Show if it's either producer or venue question? (Kai Lin wants to show newly added expressions)-->
                                             </div>
                                         </div>
                                         <div v-else-if="userID" style="display: flex; align-items: center; justify-content: center; height: 100%;">
@@ -1527,7 +1530,7 @@
                         }
                         return arr;
                     }, []);
-
+                console.log(producerQuestions)
                 // get all following venues questions with answers
                 const venueQuestions = this.venues
                     .filter(venue => JSON.stringify(this.followedVenues).includes(JSON.stringify(venue.id)))
@@ -1544,10 +1547,10 @@
                     }, []);
 
                 this.questionsUpdates = [...producerUpdates, ...venueUpdates, ...producerQuestions, ...venueQuestions];
-
-                // TO REMOVE after date is added to question answers
-                this.questionsUpdates = [...producerUpdates, ...venueUpdates];
                 
+                // TO REMOVE after date is added to question answers
+                // this.questionsUpdates = [...producerUpdates, ...venueUpdates];
+
                 // sort by date
                 this.questionsUpdates.sort((a, b) => {
                     return new Date(b.date) - new Date(a.date);


### PR DESCRIPTION
Refactored frontend to allow public users to click on buttons even when they are not logged in on the bottle listing page (bottle listing file in producers folder)

Added comments to debug why producers updates are not showing on the home page (bottle listings file in users folder)

Updated sql file ( insert data file): Removed id from insert statements so that it does not cause any issue when creating new records for tables where id is Serial (auto increment). Manual Insertion of ID Values: If you manually specify a value for the ID, the sequence may get disrupted. For instance, you may insert a value that's higher than the current maximum, or lower than the last value, potentially causing conflicts or gaps in the auto-incremented values. When the sequence is not properly maintained, it can lead to errors where the database tries to insert a row with an already used ID or a value that does not match the expected sequence. 