### PR TITLE
bug fixes: fixed bugs on randomexplore page and producer profile page

### DIFF
--- a/backend/scripts/randomContent.py
+++ b/backend/scripts/randomContent.py
@@ -302,6 +302,12 @@ def get_commenter_info(user_id, user_type):
 def getRandomListings(user_id, user_type):
     conn = g.db
 
+    if user_id == "null":
+        user_id = None
+    if user_type == "null":
+        user_type = None
+
+
     try:
 
         with conn.cursor(cursor_factory=RealDictCursor) as cursor:
@@ -508,8 +514,13 @@ def getRandomListings(user_id, user_type):
         if not listings_data:
             return jsonify({"error": "No listings found for selected date"}), 400
         
+        listings_likes = []
+        reviews_likes = []
+        producers_updates_likes = []
+        venues_updates_likes = []
+        
         # Get current user's likes for the content
-        if user_id and user_type:
+        if user_id not in (None, '') and user_type not in (None, ''):
             listings_likes = get_liked_content_ids(user_id, user_type, "Listing", [row["id"] for row in listings_data])
             reviews_likes = get_liked_content_ids(user_id, user_type, "Review", [row["id"] for row in reviews])
             producers_updates_likes = get_liked_content_ids(user_id, user_type, "pUpdate", [row["id"] for row in producers_updates])
@@ -877,9 +888,15 @@ def getNext30():
         if len(listings_data) + len(recent_reviews) + len(producers_updates) + len(venues_updates) + len(producer_reviews) + len(venue_reviews) == 0:
             return jsonify([])
         
+        listings_likes = []
+        reviews_likes = []
+        producers_updates_likes = []
+        venues_updates_likes = []
+        producer_reviews_likes = []
+        venue_reviews_likes = []
 
         # Get current user's likes for the content
-        if user_id and user_type:
+        if user_id not in (None, '', 0) and user_type not in (None, '', 'public'):
             listings_likes = get_liked_content_ids(user_id, user_type, "Listing", [row["id"] for row in listings_data])
             reviews_likes = get_liked_content_ids(user_id, user_type, "Review", [row["id"] for row in recent_reviews])
             producers_updates_likes = get_liked_content_ids(user_id, user_type, "pUpdate", [row["id"] for row in producers_updates])

--- a/frontend/src/views/Producers/ProducerProfile.vue
+++ b/frontend/src/views/Producers/ProducerProfile.vue
@@ -4676,7 +4676,6 @@ export default {
         console.log("DEBUG: Producer reviews data:", response.data);
         this.filteredTourReviews = response.data || [];
 
-        console.log("filteredTourReviews:", this.filteredTourReviews);
         this.detailedReview = this.filteredTourReviews[0] || null;
       } catch (error) {
         console.error("ERROR FETCHING REVIEWS: Failed to load producer reviews");

--- a/frontend/src/views/Producers/ProducerProfile.vue
+++ b/frontend/src/views/Producers/ProducerProfile.vue
@@ -2999,7 +2999,7 @@
                 style="cursor: pointer"
               >
                 <img
-                  :src="review['photos'][0] || defaultPhoto"
+                  :src="review.photos?.[0] || defaultPhoto"
                   alt=""
                   class="review-image"
                   style="width: 125px; height: 125px"
@@ -3016,7 +3016,7 @@
                     style="cursor: pointer"
                 >
                     <img
-                    :src="review['photos'][0] || defaultPhoto"
+                    :src="review.photos?.[0]|| defaultPhoto"
                     alt=""
                     class="review-image"
                     style="width: 200%; height: 200%"
@@ -3095,7 +3095,7 @@
                 <div class="modal-content">
                   <div class="modal-body p-4">
                     <img
-                      :src="review['photos'][0] || defaultPhoto"
+                      :src="review.photos?.[0] || defaultPhoto"
                       alt=""
                       style="width: 100%; height: auto"
                     />
@@ -4675,6 +4675,8 @@ export default {
         console.log("DEBUG: Producer reviews API response:", response.status, response.statusText);
         console.log("DEBUG: Producer reviews data:", response.data);
         this.filteredTourReviews = response.data || [];
+
+        console.log("filteredTourReviews:", this.filteredTourReviews);
         this.detailedReview = this.filteredTourReviews[0] || null;
       } catch (error) {
         console.error("ERROR FETCHING REVIEWS: Failed to load producer reviews");

--- a/frontend/src/views/RandomExplorePage.vue
+++ b/frontend/src/views/RandomExplorePage.vue
@@ -1444,7 +1444,7 @@
                                     <h4 class="fw-bold text-warning mobile-view-show">{{ content.rating }} ★</h4>
                                     <div class="d-grid">
                                       <router-link
-                                        :to="{ path: '/listing/view/' + content.reviewTarget + '/' + slugify(content.listingName) }"
+                                        :to="{ path: '/listing/view/' + content.reviewTarget + '/' + slugify(content.listingName) + '/?reviewId=' + content.id }"
                                         class="primary-clickable-text"
                                       >
                                         <button class="btn btn-read-more btn-sm fw-bold rounded-pill mobile-pb-1 mobile-pt-1 mobile-mb-2 mobile-fs-7">
@@ -2275,8 +2275,8 @@ export default {
       // modRequests: [],
 
       // for user account credentials
-      userID: "",
-      userType: "",
+      userID: 0,
+      userType: "public",
       username: "",
       displayName: "",
       isAdmin: "",
@@ -3347,6 +3347,12 @@ methods: {
 
     // Function to like content
     likeContent(contentId, contentType) {
+
+      if (!this.userID || this.userID === 0 || !this.userType || this.userType === "public") {
+        // Route to login page
+        this.$router.push('/login');
+        return;
+      }
       try {
         this.$axios.post(`${process.env.VUE_APP_API_URL}/randomContent/likeContent`, {
           userId: this.userID,
@@ -3393,6 +3399,13 @@ methods: {
 
     // Function to unlike content
     unlikeContent(contentId, contentType) {
+
+      if (!this.userID || this.userID === 0 || !this.userType || this.userType === "public") {
+        // Route to login page
+        this.$router.push('/login');
+        return;
+      }
+
       try {
         this.$axios.post(`${process.env.VUE_APP_API_URL}/randomContent/unlikeContent`, {
           userId: this.userID,
@@ -3448,8 +3461,9 @@ methods: {
     getContentLink(content) {
       switch (content.contentType) {
         case 'Listing':
-        case 'Review':
           return `/listing/view/${content.id}/${this.slugify(content.listingName)}`;
+        case 'Review':
+          return `/listing/view/${content.reviewTarget}/${this.slugify(content.listingName)} + /?reviewId=${content.id}`;
         case 'pReview':
         case 'pUpdate':
           return `/profile/producer/${content.producerId}/${this.slugify(content.producerName)}`;
@@ -3468,9 +3482,9 @@ methods: {
 
     // Function to add comment 
     async addComment(contentId, contentType, topComments) {
-      if (!this.userID || !this.userType) {
+      if (!this.userID || this.userID === 0 || !this.userType || this.userType === "public") {
         // Route to login page
-        this.$router.push({ name: 'Login' });
+        this.$router.push('/login');
         return;
       }
 
@@ -3606,8 +3620,6 @@ methods: {
       try {
 
         let endpoint = this.getContentLink(content);
-        console.log("Endpoint to copy:", endpoint);
-        
         if (endpoint) {
           // Add the hostname 
           const currentUrl = window.location.origin;

--- a/frontend/src/views/RandomExplorePage.vue
+++ b/frontend/src/views/RandomExplorePage.vue
@@ -1444,7 +1444,8 @@
                                     <h4 class="fw-bold text-warning mobile-view-show">{{ content.rating }} ★</h4>
                                     <div class="d-grid">
                                       <router-link
-                                        :to="{ path: '/listing/view/' + content.reviewTarget + '/' + slugify(content.listingName) + '/?reviewId=' + content.id }"
+                                        :to="{ path: '/listing/view/' + content.reviewTarget + '/' + slugify(content.listingName),
+                                                query: { reviewId: content.id } }"
                                         class="primary-clickable-text"
                                       >
                                         <button class="btn btn-read-more btn-sm fw-bold rounded-pill mobile-pb-1 mobile-pt-1 mobile-mb-2 mobile-fs-7">

--- a/frontend/src/views/RandomExplorePage.vue
+++ b/frontend/src/views/RandomExplorePage.vue
@@ -3273,7 +3273,6 @@ methods: {
           this.moreContent = false;
         } else {
           this.contents.push(...response.data.content);
-          console.log(response.data.content);
 
           // Update last IDs for pagination
           this.datedListingLastID = response.data.datedListingLastID;
@@ -3626,7 +3625,6 @@ methods: {
           const currentUrl = window.location.origin;
 
           await navigator.clipboard.writeText(currentUrl + endpoint);
-          console.log("Link copied to clipboard:", currentUrl + endpoint);
         }
 
         // Show success modal

--- a/frontend/src/views/RandomExplorePage.vue
+++ b/frontend/src/views/RandomExplorePage.vue
@@ -1494,24 +1494,30 @@
                               <div class="row w-100 border-top pt-2">
                                 <div class="col d-flex justify-content-around flex-wrap">
 
-                                  <!-- UnLike Button -->
-                                  <span v-if="hasLikedContent(content.id, content.contentType)" class="d-flex align-items-center">
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="black" class="bi bi-hand-thumbs-up-fill" viewBox="0 0 16 16"
-                                    style="cursor: pointer;" @click="unlikeContent(content.id, content.contentType)">
-                                      <path d="M6.956 1.745C7.021.81 7.908.087 8.864.325l.261.066c.463.116.874.456 1.012.965.22.816.533 2.511.062 4.51a10 10 0 0 1 .443-.051c.713-.065 1.669-.072 2.516.21.518.173.994.681 1.2 1.273.184.532.16 1.162-.234 1.733q.086.18.138.363c.077.27.113.567.113.856s-.036.586-.113.856c-.039.135-.09.273-.16.404.169.387.107.819-.003 1.148a3.2 3.2 0 0 1-.488.901c.054.152.076.312.076.465 0 .305-.089.625-.253.912C13.1 15.522 12.437 16 11.5 16H8c-.605 0-1.07-.081-1.466-.218a4.8 4.8 0 0 1-.97-.484l-.048-.03c-.504-.307-.999-.609-2.068-.722C2.682 14.464 2 13.846 2 13V9c0-.85.685-1.432 1.357-1.615.849-.232 1.574-.787 2.132-1.41.56-.627.914-1.28 1.039-1.639.199-.575.356-1.539.428-2.59z"/>
-                                    </svg>
-                                    <span style="cursor: pointer;" @click="unlikeContent(content.id, content.contentType)">Unlike</span>
-                                  </span>
+                                  <span class="d-flex align-items-center me-3 mb-2 mb-md-0">
+                                      <!-- UnLike Button -->
+                                    <span v-if="hasLikedContent(content.id, content.contentType)" class="d-flex align-items-center">
+                                      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="black" class="bi bi-hand-thumbs-up-fill" viewBox="0 0 16 16"
+                                      style="cursor: pointer;" @click="unlikeContent(content.id, content.contentType)">
+                                        <path d="M6.956 1.745C7.021.81 7.908.087 8.864.325l.261.066c.463.116.874.456 1.012.965.22.816.533 2.511.062 4.51a10 10 0 0 1 .443-.051c.713-.065 1.669-.072 2.516.21.518.173.994.681 1.2 1.273.184.532.16 1.162-.234 1.733q.086.18.138.363c.077.27.113.567.113.856s-.036.586-.113.856c-.039.135-.09.273-.16.404.169.387.107.819-.003 1.148a3.2 3.2 0 0 1-.488.901c.054.152.076.312.076.465 0 .305-.089.625-.253.912C13.1 15.522 12.437 16 11.5 16H8c-.605 0-1.07-.081-1.466-.218a4.8 4.8 0 0 1-.97-.484l-.048-.03c-.504-.307-.999-.609-2.068-.722C2.682 14.464 2 13.846 2 13V9c0-.85.685-1.432 1.357-1.615.849-.232 1.574-.787 2.132-1.41.56-.627.914-1.28 1.039-1.639.199-.575.356-1.539.428-2.59z"/>
+                                      </svg>
+                                      <span style="cursor: pointer;" @click="unlikeContent(content.id, content.contentType)">Unlike</span>
+                                    </span>
 
-                                  <!-- Like Button-->
-                                  <span v-else class="d-flex align-items-center">
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor"
-                                        class="bi bi-hand-thumbs-up me-1" viewBox="0 0 16 16" style="cursor: pointer;"
-                                        @click="likeContent(content.id, content.contentType)">
-                                      <path d="M8.864.046C7.908-.193 7.02.53 6.956 1.466c-.072 1.051-.23 2.016-.428 2.59-.125.36-.479 1.013-1.04 1.639-.557.623-1.282 1.178-2.131 1.41C2.685 7.288 2 7.87 2 8.72v4.001c0 .845.682 1.464 1.448 1.545 1.07.114 1.564.415 2.068.723l.048.03c.272.165.578.348.97.484.397.136.861.217 1.466.217h3.5c.937 0 1.599-.477 1.934-1.064a1.86 1.86 0 0 0 .254-.912c0-.152-.023-.312-.077-.464.201-.263.38-.578.488-.901.11-.33.172-.762.004-1.149.069-.13.12-.269.159-.403.077-.27.113-.568.113-.857 0-.288-.036-.585-.113-.856a2 2 0 0 0-.138-.362 1.9 1.9 0 0 0 .234-1.734c-.206-.592-.682-1.1-1.2-1.272-.847-.282-1.803-.276-2.516-.211a10 10 0 0 0-.443.05 9.4 9.4 0 0 0-.062-4.509A1.38 1.38 0 0 0 9.125.111zM11.5 14.721H8c-.51 0-.863-.069-1.14-.164-.281-.097-.506-.228-.776-.393l-.04-.024c-.555-.339-1.198-.731-2.49-.868-.333-.036-.554-.29-.554-.55V8.72c0-.254.226-.543.62-.65 1.095-.3 1.977-.996 2.614-1.708.635-.71 1.064-1.475 1.238-1.978.243-.7.407-1.768.482-2.85.025-.362.36-.594.667-.518l.262.066c.16.04.258.143.288.255a8.34 8.34 0 0 1-.145 4.725.5.5 0 0 0 .595.644l.003-.001.014-.003.058-.014a9 9 0 0 1 1.036-.157c.663-.06 1.457-.054 2.11.164.175.058.45.3.57.65.107.308.087.67-.266 1.022l-.353.353.353.354c.043.043.105.141.154.315.048.167.075.37.075.581 0 .212-.027.414-.075.582-.05.174-.111.272-.154.315l-.353.353.353.354c.047.047.109.177.005.488a2.2 2.2 0 0 1-.505.805l-.353.353.353.354c.006.005.041.05.041.17a.9.9 0 0 1-.121.416c-.165.288-.503.56-1.066.56z"/>
-                                    </svg>
-                                    <span style="cursor: pointer;" @click="likeContent(content.id, content.contentType)">Like</span>
+                                    <!-- Like Button-->
+                                    <span v-else class="d-flex align-items-center">
+                                      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor"
+                                          class="bi bi-hand-thumbs-up me-1" viewBox="0 0 16 16" style="cursor: pointer;"
+                                          @click="likeContent(content.id, content.contentType)">
+                                        <path d="M8.864.046C7.908-.193 7.02.53 6.956 1.466c-.072 1.051-.23 2.016-.428 2.59-.125.36-.479 1.013-1.04 1.639-.557.623-1.282 1.178-2.131 1.41C2.685 7.288 2 7.87 2 8.72v4.001c0 .845.682 1.464 1.448 1.545 1.07.114 1.564.415 2.068.723l.048.03c.272.165.578.348.97.484.397.136.861.217 1.466.217h3.5c.937 0 1.599-.477 1.934-1.064a1.86 1.86 0 0 0 .254-.912c0-.152-.023-.312-.077-.464.201-.263.38-.578.488-.901.11-.33.172-.762.004-1.149.069-.13.12-.269.159-.403.077-.27.113-.568.113-.857 0-.288-.036-.585-.113-.856a2 2 0 0 0-.138-.362 1.9 1.9 0 0 0 .234-1.734c-.206-.592-.682-1.1-1.2-1.272-.847-.282-1.803-.276-2.516-.211a10 10 0 0 0-.443.05 9.4 9.4 0 0 0-.062-4.509A1.38 1.38 0 0 0 9.125.111zM11.5 14.721H8c-.51 0-.863-.069-1.14-.164-.281-.097-.506-.228-.776-.393l-.04-.024c-.555-.339-1.198-.731-2.49-.868-.333-.036-.554-.29-.554-.55V8.72c0-.254.226-.543.62-.65 1.095-.3 1.977-.996 2.614-1.708.635-.71 1.064-1.475 1.238-1.978.243-.7.407-1.768.482-2.85.025-.362.36-.594.667-.518l.262.066c.16.04.258.143.288.255a8.34 8.34 0 0 1-.145 4.725.5.5 0 0 0 .595.644l.003-.001.014-.003.058-.014a9 9 0 0 1 1.036-.157c.663-.06 1.457-.054 2.11.164.175.058.45.3.57.65.107.308.087.67-.266 1.022l-.353.353.353.354c.043.043.105.141.154.315.048.167.075.37.075.581 0 .212-.027.414-.075.582-.05.174-.111.272-.154.315l-.353.353.353.354c.047.047.109.177.005.488a2.2 2.2 0 0 1-.505.805l-.353.353.353.354c.006.005.041.05.041.17a.9.9 0 0 1-.121.416c-.165.288-.503.56-1.066.56z"/>
+                                      </svg>
+                                      <span style="cursor: pointer;" @click="likeContent(content.id, content.contentType)">Like</span>
+                                    </span>
+
+                                    <!-- Number of Likes -->
+                                    <span class="ms-3">{{ content.totalLikes }} Likes</span>
                                   </span>
+                                  
 
                                   <!-- Comment Button -->
                                   <span class="d-flex align-items-center">
@@ -1620,7 +1626,6 @@
                                 </div>
                               </div>
 
-                              
                               <!-- Fourth Row: Comments Section -->
                               <div v-if="content.topComments && content.topComments.length" class="row w-100 mt-4 pt-2">
                                 <div class="col-12">
@@ -1630,6 +1635,7 @@
                                       v-for="(comment, index) in content.topComments"
                                       :key="index"
                                     >
+
                                       <!-- Commenter Photo Section -->
                                       <div class="col-auto me-3">
                                         <router-link
@@ -1639,8 +1645,8 @@
                                           class="primary-clickable-text"
                                         >
                                           <img
-                                            v-if="content.userPhoto"
-                                            :src="content.userPhoto"
+                                            v-if="comment.userPhoto"
+                                            :src="comment.userPhoto"
                                             class="rounded-circle"
                                             alt="Profile Photo"
                                             width="30"
@@ -3373,6 +3379,13 @@ methods: {
             break;
         }
 
+        // Update the content's like count in the UI
+        let content = this.contents.find(c => c.id === contentId && c.contentType === contentType);
+        if (content) {
+          content.totalLikes = (content.totalLikes || 0) + 1;
+        }
+        
+
       } catch (error) {
         console.error("Error liking content:", error);
       }
@@ -3403,6 +3416,13 @@ methods: {
             this.venuesUpdatesLikes = this.venuesUpdatesLikes.filter(id => id !== contentId);
             break;
         }
+
+        // Update the content's like count in the UI
+        let content = this.contents.find(c => c.id === contentId && c.contentType === contentType);
+        if (content) {
+          content.totalLikes = Math.max(content.totalLikes, 1) - 1;
+        }
+        
 
       } catch (error) {
         console.error("Error unliking content:", error);


### PR DESCRIPTION
1. When a user comments on a "User Review" or “Venue Review”, their DP defaults to the DP of the user who commented the review and not their own DP.

2. When a user comments on a “Drink Listing” or “News Release” or , their DP is not showing and defaults to a standard image.

3. Likes or likes count are not showing up on posts on the Explore page. 

4. When not logged in, Explore page defaults to error and doesn't load anymore. It should still load for public viewing. 

6. The “Share link” rerouting for specific reviews is not working. It should redirect to the bottle listing page and pull up the specific extended review. See https://drink-x.com/listing/view/1178007/danhong-makgeolli?reviewId=618 for an example of how the routing should work. 

7. [ProducerProfile.vue issue] For certain producers where their drinks have been commented on, clicking on “tours and experiences” tab on the page just leads to a blank page -> caused by error in database data where review is empty 

https://www.drink-x.com/profile/producer/32145/Beerlao 
